### PR TITLE
Add note on including modeladmin in INSTALLED_APPS

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,7 +37,7 @@ Or get the source from the application site at::
 
 Then follow these steps:
 
-1. Add ``'robots'`` to your INSTALLED_APPS_ setting.
+1. Add ``'wagtail.contrib.modeladmin'`` and ``'robots'`` to your INSTALLED_APPS_ setting.
 2. Make sure ``'django.template.loaders.app_directories.Loader'``
    is in your TEMPLATES setting. It's in there by default, so
    you'll only need to change this if you've changed that setting.


### PR DESCRIPTION
Otherwise people get:

```
Request Method:    GET
Request URL:    http://localhost:8000/admin/robots/rule/
Django Version:    2.1.7
Exception Type:    TemplateDoesNotExist
Exception Value:    
modeladmin/robots/rule/index.html, modeladmin/robots/index.html, modeladmin/index.html
````

source: https://wagtailcms.slack.com/archives/C81FGJR2S/p1557665828243600