### PR TITLE
Update index.rst

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,10 +38,7 @@ Or get the source from the application site at::
 Then follow these steps:
 
 1. Add ``'wagtail.contrib.modeladmin'`` and ``'robots'`` to your INSTALLED_APPS_ setting.
-2. Make sure ``'django.template.loaders.app_directories.Loader'``
-   is in your TEMPLATES setting. It's in there by default, so
-   you'll only need to change this if you've changed that setting.
-3. Run the ``migrate`` management command
+2. Run the ``migrate`` management command
 
 You may want to additionally setup the `Wagtail sitemap generator`_.
 


### PR DESCRIPTION
Removed step that required to add 'django.template.loaders.app_directories.Loader' is in TEMPLATES setting as it's no longer needed.