### PR TITLE
Fix crash if site without name is used

### DIFF
--- a/robots/wagtail_hooks.py
+++ b/robots/wagtail_hooks.py
@@ -16,7 +16,7 @@ class RuleAdmin(ModelAdmin):
     def affected_sites(self, obj):
         sites = obj.sites.all()
         if sites:
-            return ",".join([s.site_name for s in sites])
+            return ",".join([s.site_name or s.hostname for s in sites])
         else:
             return "All sites."
     affected_sites.short_description = 'sites'


### PR DESCRIPTION
site_name is optional, so fall back to hostname if it is not defined

see: #9 