### PR TITLE
Fixed crawl_delay rounding to int.

### DIFF
--- a/robots/templates/robots/rule_list.html
+++ b/robots/templates/robots/rule_list.html
@@ -2,7 +2,7 @@
 {% endif %}User-agent: {{ rule.robot }}{% endifchanged %}
 {% for url in rule.allowed.all %}Allow: {{ url.pattern|safe }}
 {% endfor %}{% for url in rule.disallowed.all %}Disallow: {{ url.pattern|safe }}
-{% endfor %}{% if rule.crawl_delay %}Crawl-delay: {% localize off %}{{ rule.crawl_delay|floatformat:'0' }}{% endlocalize %}
+{% endfor %}{% if rule.crawl_delay %}Crawl-delay: {% localize off %}{{ rule.crawl_delay|floatformat:'1' }}{% endlocalize %}
 {% endif %}{% endfor %}{% elif disallow_all %}User-agent: *
 Disallow: /
 {% else %}User-agent: *


### PR DESCRIPTION
Database allows to save crawl_delay as a decimal value
but template is rounding it to integer.
Changed floatformat from 0 to 1 to fix that.