### PR TITLE
Support for wagtail42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,8 @@ user:
 migrate:
 	@python testmanage.py migrate
 
-tox-215:
-	tox -e py38-dj32-wt215
-
-tox-216:
-	tox -e py38-dj32-wt216
-
-tox-3:
-	tox -e py38-dj40-wt30
-
-tox-4:
-	tox -e py38-dj40-wt40
+tox-41:
 	tox -e py38-dj41-wt41
+
+tox-42:
+	tox -e py38-dj42-wt42

--- a/robots/models.py
+++ b/robots/models.py
@@ -1,4 +1,4 @@
-import django
+from six import u
 
 from django.db import models
 from django.utils.text import get_text_list
@@ -7,20 +7,10 @@ from django.utils.translation import gettext_lazy as _
 from modelcluster.models import ClusterableModel
 from modelcluster.fields import ParentalKey
 
+from wagtail.admin.panels import FieldPanel
+from wagtail.models import Site
+
 from robots.panels import WrappedInlinepanel
-
-from wagtail import VERSION as WAGTAIL_VERSION
-if WAGTAIL_VERSION >= (3, 0):
-    from wagtail.models import Site
-    from wagtail.admin.panels import FieldPanel
-else:
-    from wagtail.core.models import Site
-    from wagtail.admin.edit_handlers import FieldPanel
-
-if django.VERSION >= (3, 0):
-    from six import u
-else:
-    from django.utils.six import u
 
 
 class BaseUrl(models.Model):

--- a/robots/panels.py
+++ b/robots/panels.py
@@ -2,11 +2,7 @@ from distutils.version import LooseVersion
 
 from django.conf import settings
 
-from wagtail import VERSION as WAGTAIL_VERSION
-if WAGTAIL_VERSION >= (3, 0):
-    from wagtail.admin.panels import InlinePanel
-else:
-    from wagtail.admin.edit_handlers import InlinePanel
+from wagtail.admin.panels import InlinePanel
 
 
 def WrappedInlinepanel(relation_name, heading='', label='',
@@ -26,15 +22,10 @@ def WrappedInlinepanel(relation_name, heading='', label='',
                 'new_card_header_text': new_card_header_text,
             }
     else:
-        if WAGTAIL_VERSION >= (2, 0):
-            defaults = {
-                'heading': heading,
-                'label': label,
-            }
-        else:
-            defaults = {
-                'label': label,
-            }
+        defaults = {
+            'heading': heading,
+            'label': label,
+        }
 
     defaults.update(kwargs)
     return klass(relation_name, **defaults)

--- a/robots/test/settings.py
+++ b/robots/test/settings.py
@@ -46,7 +46,7 @@ INSTALLED_APPS = [
     "wagtail.contrib.routable_page",
     "wagtail.contrib.styleguide",
     "wagtail.sites",
-    "wagtail.core",
+    "wagtail",
     "taggit",
     "rest_framework",
     "django.contrib.admin",

--- a/robots/test/urls.py
+++ b/robots/test/urls.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 
 from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
-from wagtail.core import urls as wagtail_urls
+from wagtail import urls as wagtail_urls
 
 urlpatterns = [
     path("django-admin/", admin.site.urls),

--- a/robots/views.py
+++ b/robots/views.py
@@ -1,23 +1,13 @@
-import django
 from django.db.models import Q
 from django.views.decorators.cache import cache_page
 from django.views.generic import ListView
+from django.urls import NoReverseMatch, reverse
+
+from wagtail.contrib.sitemaps.views import sitemap
+from wagtail.models import Site
 
 from robots import settings
 from robots.models import Rule
-
-if django.VERSION[:2] >= (2, 0):
-    from django.urls import NoReverseMatch, reverse
-else:
-    from django.core.urlresolvers import NoReverseMatch, reverse
-
-from wagtail import VERSION as WAGTAIL_VERSION # noqa
-if WAGTAIL_VERSION >= (3, 0):
-    from wagtail.models import Site
-else:
-    from wagtail.core.models import Site
-
-from wagtail.contrib.sitemaps.views import sitemap
 
 
 class RuleList(ListView):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         ],
     },
     install_requires=[
-        'wagtail>=2.15',
+        'wagtail>=4.1',
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',
@@ -37,12 +37,11 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Framework :: Django',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.0',
         'Framework :: Django :: 4.1',
-        'Framework :: Wagtail :: 2',
-        'Framework :: Wagtail :: 3',
         'Framework :: Wagtail :: 4',
     ]
 )

--- a/testmanage.py
+++ b/testmanage.py
@@ -56,7 +56,7 @@ def runtests():
     try:
         execute_from_command_line(argv)
     finally:
-        from wagtail.tests.settings import STATIC_ROOT, MEDIA_ROOT
+        from wagtail.test.settings import STATIC_ROOT, MEDIA_ROOT
 
         shutil.rmtree(STATIC_ROOT, ignore_errors=True)
         shutil.rmtree(MEDIA_ROOT, ignore_errors=True)

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,9 @@ skipsdist = True
 usedevelop = True
 
 envlist = 
-    py{37}-dj{32}-wt{215,216}
-    py{38,39,310}-dj{32,40}-wt{216,30,40}
-    py{39,310}-dj{41}-wt{40,41}
+    py{37}-dj{32}-wt{41,42}
+    py{38,39,310}-dj{32,40,41}-wt{41,42}
+    py{311}-dj{41}-wt{40,41}
 
 [testenv]
 deps = -r{toxinidir}/test-requirements.txt


### PR DESCRIPTION
Hi

This PR updates the package to allow wagtail 4.1+ and removes the support for wagtail < 4.1

If you would prefer to keep support for versions older than the current LTS of 4.1 please let me know and I can alter it.